### PR TITLE
-- use vlan description as vlan name when vlan name is not set in Auvik

### DIFF
--- a/layer8_app/ssot_jobs/diffsync/adapters/auvik.py
+++ b/layer8_app/ssot_jobs/diffsync/adapters/auvik.py
@@ -143,6 +143,12 @@ class AuvikAdapter(DiffSync):
 
         for _vlan in auvik_vlans:
             vlan_name = getattr(_vlan.attributes, "network_name", None)
+            if vlan_name is None or vlan_name == "":
+                vlan_name = getattr(_vlan.attributes, "description", None)
+                if vlan_name is None or vlan_name == "":
+                    if self.job.debug:
+                        self.job.logger.error(f"VLAN name is not set in Auvik. Skipping.")
+                    continue
             try:
                 vlan_id = int(getattr(_vlan.attributes, "description").split()[1])
             except ValueError:


### PR DESCRIPTION
-- if no vlan name or vlan description in auvik, skip the VLAN